### PR TITLE
feat: add more ratio check options

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,2 @@
-*   text=auto
+*           text=auto 
+*.conf      linguist-language=EditorConfig

--- a/README.md
+++ b/README.md
@@ -1,33 +1,51 @@
-## mpv-boxtowide
-<img width="1483" height="302" alt="Terminal" src="https://github.com/user-attachments/assets/da6aa810-f25f-4793-8067-0c9f1a08f120" />
+## BoxToWide
+<img width="1483" height="302" alt="Terminal" src="https://github.com/user-attachments/assets/a647d587-b21a-4a71-b7d5-360a21df3105" />
 
-This script detects if a video has a 4:3 aspect ratio and automatically adjusts it to 16:9 (wide).
+This script automatically adjusts video aspect ratios in mpv. By default, it converts legacy 4:3 content to 16:9, but it can also handle other ratios using configurable range or precise checks.
 
-It is designed for libraries with older 4:3 content, stretching them to 16:9 without manual intervention. The script aligns with my preference for a simple [mpv configuration](https://github.com/Samillion/mpv-conf) to fit this straightforward use case.
+It supports:
+- Range-based detection for slightly off legacy ratios
+- Accurate ratio detection with a tolerance for precise matching
+- Flexible file/URL selection based on extensions or URLs
+- Ideal for libraries with older or mixed aspect-ratio content, it streamlines widescreen conversion without manual intervention, while giving users full control over which checks to apply.
 
 ## Options
-To adjust options, simply change the values inside `local options` within the script.
+To adjust options, simply change the values inside `boxtowide.conf` (recommended) or adjust `local options` within the script.
 
-```lua
-local options = {
-    -- target aspect ratio for conversion
-    target_ratio = "16:9",
+```EditorConfig
+# file extensions the script will check
+# separate each with a comma
+video_exts=3gp,asf,avi,flv,m4v,mkv,mov,mp4,mp4v,mpeg,mpg,mts,ogv,rmvb,ts,webm,wmv
 
-    -- usually 4:3 would only need 1.3333
-    -- many old videos use weird ratios, this min/max range covers most of them
-    min_ratio = 1.28,
-    max_ratio = 1.39,
+# target aspect ratio for conversion
+# common ratios:
+# 4:3 (1.3333), 16:9 (1.7778), 16:10 (1.6)
+# 1.85:1, 2.00:1, 2.20:1, 2.35:1, 2.39:1, 2.76:1
+target_ratio=16:9
 
-    -- file extensions the script will do a ratio check on
-    video_exts = {
-        "3g2", "3gp", "asf", "avi", "f4v", "flv", "h264", "h265", "ivf", "m2t", "m2ts", 
-        "m4v", "mj2", "mkv", "mov", "mp4", "mp4v", "mpeg", "mpg", "mxf", "mts", "ogv", 
-        "rmvb", "ts", "webm", "wmv", "y4m"
-    },
+# ratio check type (one or both can be used)
+# check if aspect is within min_ratio to max_ratio
+range_check=yes
 
-    -- regex to detect urls (for ytdl videos)
-    url_pattern = "^[%a][%a%d+.-]*://",
-}
+# check if aspect matches accurate_ratio + accurate_tolerance
+accurate_check=yes
+
+# many old videos use weird ratios; usually 4:3 is ~1.3333
+min_ratio=1.28
+max_ratio=1.39
+
+# common decimal ratios:
+# 1.3333 (4:3), 1.7778 (16:9), 1.6 (16:10)
+# 1.5 (3:2), 1.25 (5:4), 1.85 (1.85:1), 2.0 (2.00:1)
+# 2.35 (2.35:1), 2.39 (2.39:1 scope)
+accurate_ratio=1.3333
+
+# allowed deviation; 0 = exact match
+accurate_tolerance=0.01
+
+# regex to detect urls (e.g. ytdl videos)
+# a simpler pattern: "^%a+://"
+url_pattern=^[%a][%a%d+.-]*://
 ```
 
 ## How to install
@@ -41,10 +59,9 @@ Simply place `boxtowide.lua` in the corresponding mpv scripts location of your o
 > More information about files locations can be found  [here](https://mpv.io/manual/master/#files)
 
 ```
-config/mpv
-│   input.conf
-│   mpv.conf
-│
-└───scripts
-        boxtowide.lua
+📁 mpv/
+├── 📁 script-opts/
+│   └── 📄 boxtowide.conf
+└── 📁 scripts/
+    └── 📄 boxtowide.lua
 ```

--- a/boxtowide.conf
+++ b/boxtowide.conf
@@ -1,0 +1,33 @@
+# file extensions the script will check
+# separate each with a comma
+video_exts=3gp,asf,avi,flv,m4v,mkv,mov,mp4,mp4v,mpeg,mpg,mts,ogv,rmvb,ts,webm,wmv
+
+# target aspect ratio for conversion
+# common ratios:
+# 4:3 (1.3333), 16:9 (1.7778), 16:10 (1.6)
+# 1.85:1, 2.00:1, 2.20:1, 2.35:1, 2.39:1, 2.76:1
+target_ratio=16:9
+
+# ratio check type (one or both can be used)
+# check if aspect is within min_ratio to max_ratio
+range_check=yes
+
+# check if aspect matches accurate_ratio + accurate_tolerance
+accurate_check=yes
+
+# many old videos use weird ratios; usually 4:3 is ~1.3333
+min_ratio=1.28
+max_ratio=1.39
+
+# common decimal ratios:
+# 1.3333 (4:3), 1.7778 (16:9), 1.6 (16:10)
+# 1.5 (3:2), 1.25 (5:4), 1.85 (1.85:1), 2.0 (2.00:1)
+# 2.35 (2.35:1), 2.39 (2.39:1 scope)
+accurate_ratio=1.3333
+
+# allowed deviation; 0 = exact match
+accurate_tolerance=0.01
+
+# regex to detect urls (e.g. ytdl videos)
+# a simpler pattern: "^%a+://"
+url_pattern=^[%a][%a%d+.-]*://

--- a/boxtowide.lua
+++ b/boxtowide.lua
@@ -8,47 +8,38 @@
 --]]
 
 local options = {
-    -- file extensions the script will do a ratio check on
-    -- separate each extension with a comma
+    -- file extensions the script will check
+    -- separate each with a comma
     video_exts = "3gp,asf,avi,flv,m4v,mkv,mov,mp4,mp4v,mpeg,mpg,mts,ogv,rmvb,ts,webm,wmv",
 
     -- target aspect ratio for conversion
     -- common ratios:
-    -- 4:3 (1.3333), 16:9 (1.7778), 16:10 (1.6),
-    -- 1.85:1, 2.00:1, 2.20:1,
-    -- 2.35:1, 2.39:1 (modern scope), 2.76:1
+    -- 4:3 (1.3333), 16:9 (1.7778), 16:10 (1.6)
+    -- 1.85:1, 2.00:1, 2.20:1, 2.35:1, 2.39:1, 2.76:1
     target_ratio = "16:9",
 
     -- ratio check type (one or both can be used)
-    -- use range min_ratio -> max_ratio check
+    -- check if aspect is within min_ratio to max_ratio
     range_check = true,
 
-    -- use accurate_ratio + accurate_tolerance
+    -- check if aspect matches accurate_ratio + accurate_tolerance
     accurate_check = true,
 
-    -- usually 4:3 would only need 1.3333
-    -- many old videos use weird ratios, this min/max range covers most of them
+    -- many old videos use weird ratios; usually 4:3 is ~1.3333
     min_ratio = 1.28,
     max_ratio = 1.39,
 
-    -- a precise ratio check (decimal form)
-    -- instead of relying only on a min/max range
     -- common decimal ratios:
-    -- 1.3333 (4:3), 1.7778 (16:9), 1.6 (16:10),
-    -- 1.5 (3:2), 1.25 (5:4),
-    -- 1.85 (1.85:1), 2.0 (2.00:1),
+    -- 1.3333 (4:3), 1.7778 (16:9), 1.6 (16:10)
+    -- 1.5 (3:2), 1.25 (5:4), 1.85 (1.85:1), 2.0 (2.00:1)
     -- 2.35 (2.35:1), 2.39 (2.39:1 scope)
-    -- to disable accurate check, set to 0
     accurate_ratio = 1.3333,
 
-    -- allowed difference for accurate_ratio comparison
-    -- example: with accurate_ratio = 1.3333 and accurate_tolerance = 0.01,
-    -- values from 1.3233 to 1.3433 will match.
-    -- Set to 0 to require exact match
+    -- allowed deviation; 0 = exact match
     accurate_tolerance = 0.01,
 
-    -- regex to detect urls (for ytdl videos)
-    -- a simpler pattern: "^%a+://"
+    -- regex to detect urls (e.g. ytdl videos)
+    -- simpler pattern: "^%a+://"
     url_pattern = "^[%a][%a%d+.-]*://",
 }
 

--- a/boxtowide.lua
+++ b/boxtowide.lua
@@ -8,64 +8,107 @@
 --]]
 
 local options = {
+    -- file extensions the script will do a ratio check on
+    -- separate each extension with a comma
+    video_exts = "3gp,asf,avi,flv,m4v,mkv,mov,mp4,mp4v,mpeg,mpg,mts,ogv,rmvb,ts,webm,wmv",
+
     -- target aspect ratio for conversion
+    -- common ratios:
+    -- 4:3 (1.3333), 16:9 (1.7778), 16:10 (1.6),
+    -- 1.85:1, 2.00:1, 2.20:1,
+    -- 2.35:1, 2.39:1 (modern scope), 2.76:1
     target_ratio = "16:9",
+
+    -- ratio check type (one or both can be used)
+    -- use range min_ratio -> max_ratio check
+    range_check = true,
+
+    -- use accurate_ratio + accurate_tolerance
+    accurate_check = true,
 
     -- usually 4:3 would only need 1.3333
     -- many old videos use weird ratios, this min/max range covers most of them
     min_ratio = 1.28,
     max_ratio = 1.39,
 
-    -- file extensions the script will do a ratio check on
-    video_exts = {
-        "3g2", "3gp", "asf", "avi", "f4v", "flv", "h264", "h265", "ivf", "m2t", "m2ts", 
-        "m4v", "mj2", "mkv", "mov", "mp4", "mp4v", "mpeg", "mpg", "mxf", "mts", "ogv", 
-        "rmvb", "ts", "webm", "wmv", "y4m"
-    },
+    -- a precise ratio check (decimal form)
+    -- instead of relying only on a min/max range
+    -- common decimal ratios:
+    -- 1.3333 (4:3), 1.7778 (16:9), 1.6 (16:10),
+    -- 1.5 (3:2), 1.25 (5:4),
+    -- 1.85 (1.85:1), 2.0 (2.00:1),
+    -- 2.35 (2.35:1), 2.39 (2.39:1 scope)
+    -- to disable accurate check, set to 0
+    accurate_ratio = 1.3333,
+
+    -- allowed difference for accurate_ratio comparison
+    -- example: with accurate_ratio = 1.3333 and accurate_tolerance = 0.01,
+    -- values from 1.3233 to 1.3433 will match.
+    -- Set to 0 to require exact match
+    accurate_tolerance = 0.01,
 
     -- regex to detect urls (for ytdl videos)
+    -- a simpler pattern: "^%a+://"
     url_pattern = "^[%a][%a%d+.-]*://",
 }
 
 local msg = require "mp.msg"
 local checked = false
+require 'mp.options'.read_options(options, "boxtowide")
 
-local function box_ratio(_, value)
-    if checked or not value then return end
-    checked = true
+local function extension_matches(path, extensions)
+    if not path or not extensions or path:match(options.url_pattern) then
+        return false
+    end
 
-    if value >= options.min_ratio and value <= options.max_ratio then
-        local video_track = mp.get_property_native("current-tracks/video")
-        -- only apply on videos (second check in case of ytdl)
-        if video_track and not video_track.image then
-            mp.set_property(
-                "file-local-options/video-aspect-override",
-                options.target_ratio
-            )
-            msg.info("Video aspect-ratio changed from 4:3 to " .. options.target_ratio)
+    local ext = path:match("%.([^%.]+)$")
+    if not ext then return false end
+
+    ext = ext:lower()
+
+    for listed_ext in string.gmatch(extensions, '([^,]+)') do
+        listed_ext = listed_ext:match("^%s*(.-)%s*$"):lower()
+        if ext == listed_ext then
+            return true
         end
     end
 
-    -- ensure single ratio check per file
+    return false
+end
+
+local function box_ratio(_, value)
+    if checked or not value or value <= 0 then return end
+    checked = true
+
+    local in_range = options.range_check and value >= options.min_ratio and value <= options.max_ratio
+    local accurate_match = false
+
+    if options.accurate_check and options.accurate_ratio and options.accurate_ratio > 0 then
+        accurate_match = math.abs(value - options.accurate_ratio) <= options.accurate_tolerance
+    end
+
+    if in_range or accurate_match then
+        local video_track = mp.get_property_native("current-tracks/video")
+
+        if video_track and not video_track.image then
+            mp.set_property("file-local-options/video-aspect-override", options.target_ratio)
+            local changed = string.format(
+                "Aspect ratio %.4f matched (range=%s, accurate=%s). Changed to %s", 
+                value, tostring(in_range), tostring(accurate_match), options.target_ratio
+            )
+            msg.info(changed)
+        end
+    end
+
     mp.unobserve_property(box_ratio)
 end
-
-local function create_set(t)
-    local set = {}
-    for _, v in ipairs(t) do
-        set[tostring(v):lower()] = true
-    end
-    return set
-end
-
-local list = create_set(options.video_exts)
 
 local function path_check()
     checked = false
     local path = mp.get_property("path", "")
-    local ext = path:match("%.([^%.]+)$") or "nomatch"
+    if not path then return end
 
-    if list[ext:lower()] or path:match(options.url_pattern) then
+    if extension_matches(path, options.video_exts) or path:match(options.url_pattern) then
         mp.observe_property("video-params/aspect", "number", box_ratio)
     end
 end


### PR DESCRIPTION
Changes:
- Add `boxtowide.conf` so users can customize options without having to edit the script
- Make `video_exts` list option simpler
- Add two ratio checks options `range_check` and `accurate_check` (one or both can be used)
  - `range_check`: check if aspect is within `min_ratio` to `max_ratio`
  - `accurate_check`: check if aspect matches `accurate_ratio` + `accurate_tolerance`
- Add `accurate_ratio` option, to check for exact ratio match
- Add `accurate_tolerance` for allowed deviations in `accurate_ratio `